### PR TITLE
Add documentation about Rubocop usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ plugins:
       target_rails_version: 7.0
 ```
 
+### Rubocop
+
+If you're using Rubocop, you'll want to inherit from the `standard-rails` gem in your `rubocop.yml` file. Here's an example:
+
+```yaml
+require:
+  - rubocop-rails
+  - standard
+  - standard-rails
+
+inherit_gem:
+  standard: config/base.yml
+  standard-rails: config/base.yml
+```
+
 ## Code of Conduct
 
 This project follows Test Double's [code of


### PR DESCRIPTION
I had a decent amount of trouble trying to figure out how to properly update my `rubocop.yml` file when adding `standard-rails`. So I added this documentation to hopefully help others.

However, if you all believe it won't be super useful or that this should have been self-explanatory, feel free to close this PR. This could have just been my lack of Rubocop/Standard knowledge.