### PR TITLE
Install standard-rails in development/test group

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ gem](https://github.com/standardrb/standard).
 To install it, you'll want to start by adding it to your Gemfile:
 
 ```ruby
-gem "standard-rails"
+gem "standard-rails", group: [:development, :test]
 ```
 
 ## Configuration


### PR DESCRIPTION
https://github.com/standardrb/standard?tab=readme-ov-file#install
`standard` gem installs into development/test group, so this gem should also belongs to the same group.