### PR TITLE
Move `standard` to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,4 @@ source "https://rubygems.org"
 gemspec
 gem "rake"
 gem "minitest"
-gem "standard"
 gem "m"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     standard-rails (0.2.0)
       lint_roller (~> 1.0)
       rubocop-rails (~> 2.20.2)
+      standard (~> 1.32.1)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +15,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    base64 (0.1.1)
     concurrent-ruby (1.2.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -27,7 +27,7 @@ GEM
     method_source (1.0.0)
     minitest (5.20.0)
     parallel (1.23.0)
-    parser (3.2.2.3)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
     racc (1.7.1)
@@ -36,12 +36,11 @@ GEM
     rake (13.0.6)
     regexp_parser (2.8.1)
     rexml (3.2.6)
-    rubocop (1.56.2)
-      base64 (~> 0.1.1)
+    rubocop (1.57.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -58,10 +57,10 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
-    standard (1.31.0)
+    standard (1.32.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.56.0)
+      rubocop (~> 1.57.2)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.2)
     standard-custom (1.0.2)
@@ -83,7 +82,6 @@ DEPENDENCIES
   m
   minitest
   rake
-  standard
   standard-rails!
 
 BUNDLED WITH

--- a/standard-rails.gemspec
+++ b/standard-rails.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "lint_roller", "~> 1.0"
   spec.add_dependency "rubocop-rails", "~> 2.20.2"
+  spec.add_dependency "standard", "~> 1.32.1"
 end


### PR DESCRIPTION
When we want to use `standard-rails` we need `standardrb` command, which comes from `standard` gem.
Although we can install these two gems separately, it seems natural that `standard-rails` has `standard` as a dependency.