### PR TITLE
Fix configuration warnings

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -134,7 +134,7 @@ Rails/DotSeparatedKeys:
 
 Rails/DuplicateAssociation:
   Enabled: true
-  Autocorrect: false
+  AutoCorrect: false
 
 Rails/DuplicateScope:
   Enabled: true
@@ -366,9 +366,6 @@ Rails/SkipsModelValidations:
 
 Rails/SquishedSQLHeredocs:
   Enabled: false
-
-Rails/StripHeredoc:
-  Enabled: true
 
 Rails/StripHeredoc:
   Enabled: true


### PR DESCRIPTION
Fixes issues identified in https://github.com/standardrb/standard-rails/issues/23.

- Fixes case on `AutoCorrect` parameter
- Removes duplicate configuration for Rails/StripHeredoc Cop

I tested this by running locally on one of our repositories to make sure that the warnings no longer appear.