### PR TITLE
Fix incompatibility with betterlint

### DIFF
--- a/standard-rails.gemspec
+++ b/standard-rails.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "lint_roller", "~> 1.0"
-  spec.add_dependency "rubocop-rails", "~> 2.23.1"
+  spec.add_dependency "rubocop-rails", "~> 2.24.0"
 end


### PR DESCRIPTION
Align rubocop-rails version requirement with latest betterlint v1.9 i.e. stop blocking betterlint upgrades