### PR TITLE
Disable `Rails/DynamicFindBy`

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -134,7 +134,7 @@ Rails/DurationArithmetic:
   Enabled: true
 
 Rails/DynamicFindBy:
-  Enabled: true
+  Enabled: false
 
 Rails/EagerEvaluationLogMessage:
   Enabled: true


### PR DESCRIPTION
[`Rails/DynamicFindBy`](https://rubydoc.info/gems/rubocop/0.47.1/RuboCop/Cop/Rails/DynamicFindBy) rule triggers when creating a DRY method to query records via a nested JSONB value:

```ruby
class Dummy
  def self.find_by_stripe_id(stripe_id)
    find_by!("metadata @> ?", {stripe: {id: stripe_id}}.to_json)
  end

  def stripe_id=(stripe_id)
    # This raises `Rails/DynamicFindBy`
    raise ActiveRecord::RecordNotUnique if self.class.find_by_stripe_id(stripe_id).present?
    metadata["stripe"]["id"] = stripe_id
  end
end
```

Closes standardrb/standard#628.