### PR TITLE
Disable `Rails/PluckId` cop by default

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -254,7 +254,7 @@ Rails/Pluck:
   Enabled: true
 
 Rails/PluckId:
-  Enabled: true
+  Enabled: false
 
 Rails/PluckInWhere:
   Enabled: true


### PR DESCRIPTION
This cop was originally disabled with the original rubocop import: https://github.com/standardrb/standard-rails/commit/71e48d5e0af91061b3097a4ac8796776e831c908#diff-da3213a24b350fa386ff3bab0d6b239112408c3fe4f986cbd9d5236f7e0b61e4R458-R463

It was subsequently enabled during a mass enable commit: https://github.com/standardrb/standard-rails/commit/24bc50f5228015b806aa46fff9a5b33bfd8f3558#diff-da3213a24b350fa386ff3bab0d6b239112408c3fe4f986cbd9d5236f7e0b61e4R248-R249

As discussed on this issue, the cop is unsafe by default and frequently gets false positives: https://github.com/rubocop/rubocop-rails/issues/301

It is disabled by default in most recent rubocop release, for same reasons: https://github.com/rubocop/rubocop-rails/blob/v2.25.0/config/default.yml#L746-L751

Discussion of why to disable on: https://github.com/standardrb/standard-rails/issues/31