### PR TITLE
Disable `Rails/ActionFilter` cop

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -37,7 +37,7 @@ Rails/ActionControllerTestCase:
   Enabled: false
 
 Rails/ActionFilter:
-  Enabled: true
+  Enabled: false
 
 Rails/ActionOrder:
   Enabled: false


### PR DESCRIPTION
History in standard-rails:

- Disabled in initial rules import
- Enabled in bulk rails rule enable commit

This cop is both disabled by default and deprecated in rubocop-rails: https://github.com/rubocop/rubocop-rails/pull/1149

Rationale is that the cop is only relevant to Rails versions so early they are no longer supported by rubocop-rails.

Previous: https://github.com/standardrb/standard-rails/pull/36