### PR TITLE
Disable `Rails/UnusedIgnoredColumns` cop

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -396,7 +396,7 @@ Rails/UnknownEnv:
   Enabled: false
 
 Rails/UnusedIgnoredColumns:
-  Enabled: true
+  Enabled: false
 
 Rails/UnusedRenderContent:
   Enabled: true


### PR DESCRIPTION
History in standard-rails:

- Initially added during a rubocop-rails bump, as pending
- Changed to enabled during the RailsConf vote changes

Disabled on rubocop-rails side in release 2.25.0 - https://github.com/rubocop/rubocop-rails/releases/tag/v2.25.0

Rationale - https://github.com/rubocop/rubocop-rails/pull/1252

Previous: https://github.com/standardrb/standard-rails/pull/36