### PR TITLE
Update `rubocop-rails` to version 2.25.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     standard-rails (1.0.2)
       lint_roller (~> 1.0)
-      rubocop-rails (~> 2.23.1)
+      rubocop-rails (~> 2.25.0)
 
 GEM
   remote: https://rubygems.org/
@@ -37,7 +37,7 @@ GEM
     minitest (5.20.0)
     mutex_m (0.2.0)
     parallel (1.24.0)
-    parser (3.3.0.2)
+    parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
@@ -57,16 +57,16 @@ GEM
       rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
-    rubocop-rails (2.23.1)
+    rubocop-rails (2.25.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     standard (1.33.0)
@@ -89,6 +89,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -99,4 +100,4 @@ DEPENDENCIES
   standard-rails!
 
 BUNDLED WITH
-   2.4.10
+   2.5.11

--- a/config/base.yml
+++ b/config/base.yml
@@ -418,3 +418,6 @@ Rails/WhereNot:
 
 Rails/WhereNotWithMultipleConditions:
   Enabled: false
+
+Rails/WhereRange:
+  Enabled: true

--- a/lib/standard/rails/load_rubocop_rails_without_the_monkey_patch.rb
+++ b/lib/standard/rails/load_rubocop_rails_without_the_monkey_patch.rb
@@ -7,7 +7,7 @@
 # of RuboCop built-in cops in this file, we need to monitor it for changes
 # in rubocop-rails and keep it up to date.
 #
-# Last updated from rubocop-rails v2.23.1
+# Last updated from rubocop-rails v2.25.0
 
 # frozen_string_literal: true
 

--- a/standard-rails.gemspec
+++ b/standard-rails.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "lint_roller", "~> 1.0"
-  spec.add_dependency "rubocop-rails", "~> 2.23.1"
+  spec.add_dependency "rubocop-rails", "~> 2.25.0"
 end


### PR DESCRIPTION
In the aftermath of the recent PRs aligning various rules with rubocop-rails defaults, I noticed that we're behind on releases, so this is a few changes:

- Bump the rubocop-rails version in gemspec, and regenerate the monkey patch file meta data and Gemfile.lock (there are some incidental side changes in there as well from my local env, which I think dont matter?)
- Opt in to `Rails/WhereRange`, which a) is pending in rubocop-rails, b) in my own discretion seems like a reasonable thing to enable (https://docs.rubocop.org/rubocop-rails/cops_rails.html#railswhererange) ... if this should be separate PR/issue first to get proper discussion, LMK

Separately - curious what the protocol for bumping s-r releases is? Would love to get the recent PRs (and maybe this?) into a tagged release?