### PR TITLE
Restore 3.0 to CI, bump gemspec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby-version:
+          - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'

--- a/standard-rails.gemspec
+++ b/standard-rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A Standard plugin that adds Rails-specific rules to Standard"
   spec.homepage = "https://github.com/testdouble/standard-rails"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Context: https://github.com/standardrb/standard-performance/pull/26#issuecomment-2171548753

Prep for possible aligned release of standard/-rails/-performance