### PR TITLE
configure InverseOf to ignore scopes

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -216,6 +216,7 @@ Rails/Inquiry:
 
 Rails/InverseOf:
   Enabled: true
+  IgnoreScopes: true
 
 Rails/LexicallyScopedActionFilter:
   Enabled: true


### PR DESCRIPTION
scope's inverses are automatically inferred with rails 7+

closes #51 

I manually tested this locally and it resolved my issue. (Which means I managed not to typo `IgnoreScopes: true` :smile:)