### PR TITLE
disable InverseOf cop

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -215,7 +215,7 @@ Rails/Inquiry:
   Enabled: false
 
 Rails/InverseOf:
-  Enabled: true
+  Enabled: false
 
 Rails/LexicallyScopedActionFilter:
   Enabled: true


### PR DESCRIPTION
see https://github.com/standardrb/standard-rails/issues/51 and https://github.com/standardrb/standard-rails/pull/52 for some details about why this cop can be problematic.
TLDR: it currently flags associations with scopes even though Rails 7+ handles them automatically. it also flags the less problematic side of has_many associations and fails to stop N+1 queries via its suggested fix.

supercedes #52 

I made this PR because I feel like until the cop is suggesting more helpful fixes, it should be disabled.