### PR TITLE
disable BulkChangeTable cop

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -91,7 +91,7 @@ Rails/Blank:
   Enabled: true
 
 Rails/BulkChangeTable:
-  Enabled: true
+  Enabled: false
 
 Rails/CompactBlank:
   Enabled: true


### PR DESCRIPTION
While this cop can offer faster migrations for very large databases, it also leads to more complex, more error-prone, and less understandable migrations for smaller (most) projects. For example, `change_table` with `bulk: true` does not properly reverse migrations that add columns and indices on those columns. The columns are dropped first and it then attempts to drop the indices, which were automatically dropped when the columns were dropped, resulting in an error. Furthermore, this situation is harder to debug with `bulk: true` as the standard rails migration logging just logs `change_table(:bulk=>true)`, not the individual columns and indices being added/dropped. Finally, it only alerts on a subset of alter table statements, allowing some to be outside a `change_table` but forcing others to be inside the `change_table` block.