### PR TITLE
Disable `Rails/WhereRange`. Fixes #56

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -420,4 +420,4 @@ Rails/WhereNotWithMultipleConditions:
   Enabled: false
 
 Rails/WhereRange:
-  Enabled: true
+  Enabled: false


### PR DESCRIPTION
I believe it is questionable whether beginless ranges make readable alternatives to comparison operators in SQL string fragments. Also there is no equivalent Range based clause for 'greater than' since ranges always include their start.

Hopefully Rails will gives us a solution to such `where` clauses in the future that will allow us to avoid writing fragments of SQL while also retaining readability etc

See #56 

Thank you!