### PR TITLE
Silence Standard warnings by filtering rubocop-rails-only params

### DIFF
--- a/lib/standard/rails/load_rubocop_rails_without_the_monkey_patch.rb
+++ b/lib/standard/rails/load_rubocop_rails_without_the_monkey_patch.rb
@@ -7,7 +7,7 @@
 # of RuboCop built-in cops in this file, we need to monitor it for changes
 # in rubocop-rails and keep it up to date.
 #
-# Last updated from rubocop-rails v2.31.0
+# Last updated from rubocop-rails v2.32.0
 
 # frozen_string_literal: true
 

--- a/test/standard/rails/plugin_test.rb
+++ b/test/standard/rails/plugin_test.rb
@@ -12,5 +12,32 @@ module Standard::Rails
 
       assert_equal 5.2, result.value["AllCops"]["TargetRailsVersion"]
     end
+
+    def test_filters_migrated_schema_version_from_all_cops
+      subject = Plugin.new({})
+
+      result = subject.rules(LintRoller::Context.new)
+
+      refute_includes result.value.fetch("AllCops", {}).keys, "MigratedSchemaVersion"
+    end
+
+    def test_removes_useless_access_modifier_block
+      subject = Plugin.new({})
+
+      result = subject.rules(LintRoller::Context.new)
+
+      assert_nil result.value["Lint/UselessAccessModifier"]
+    end
+
+    def test_no_parameter_warnings_when_validating_config
+      subject = Plugin.new({})
+      rules = subject.rules(LintRoller::Context.new)
+
+      _, err = capture_io do
+        RuboCop::Config.create(rules.value, "inline.yml", check: true)
+      end
+
+      assert_equal "", err
+    end
   end
 end


### PR DESCRIPTION
Standard validates plugin YAML like user config against a temporary, minimal default. rubocop-rails’ default.yml contains two entries that are fine when loaded by RuboCop’s plugin integrator as defaults, but trigger warnings when validated early by Standard.

This change drops those from the rules as Standard merges configs for RuboCop

- Remove AllCops/MigratedSchemaVersion and nil AllCops/TargetRailsVersion to silence RuboCop param warnings; both deletions are behavior-neutral (epoch default skips nothing; nil TargetRailsVersion lets RuboCop infer Rails version).

- Lint/UselessAccessModifier: Standard’s base disables this cop. Removing the rubocop-rails-specific parameters does not enable the cop and has no effect on linting outcomes.

Also adds a test that will fail the build if anything prints to stderr

Fixes #72