### PR TITLE
Mirror the rubocop-rails warning silence workaround

### DIFF
--- a/lib/standard/rails/load_rubocop_rails_without_the_monkey_patch.rb
+++ b/lib/standard/rails/load_rubocop_rails_without_the_monkey_patch.rb
@@ -7,7 +7,7 @@
 # of RuboCop built-in cops in this file, we need to monitor it for changes
 # in rubocop-rails and keep it up to date.
 #
-# Last updated from rubocop-rails v2.31.0
+# Last updated from rubocop-rails v2.32.0
 
 # frozen_string_literal: true
 

--- a/lib/standard/rails/plugin.rb
+++ b/lib/standard/rails/plugin.rb
@@ -24,6 +24,11 @@ module Standard
       def rules(context)
         trick_rubocop_into_thinking_we_required_rubocop_rails!
 
+        # Mirror a rubocop-rails internal workaround to avoid "Warning: AllCops does not support..." output
+        without_warnings do
+          RuboCop::ConfigValidator.const_set(:COMMON_PARAMS, RuboCop::ConfigValidator::COMMON_PARAMS.dup << "MigratedSchemaVersion")
+        end
+
         LintRoller::Rules.new(
           type: :object,
           config_format: :rubocop,
@@ -54,7 +59,7 @@ module Standard
       # See: https://github.com/standardrb/standard-rails/issues/25#issuecomment-1881127173
       def without_extended_rule_configs(rules)
         rules.reject { |(name, _)|
-          ["Style/InvertibleUnlessCondition", "Lint/SafeNavigationChain"].include?(name)
+          ["Style/InvertibleUnlessCondition", "Lint/SafeNavigationChain", "Lint/UselessAccessModifier"].include?(name)
         }.to_h
       end
 

--- a/lib/standard/rails/plugin.rb
+++ b/lib/standard/rails/plugin.rb
@@ -24,9 +24,9 @@ module Standard
       def rules(context)
         trick_rubocop_into_thinking_we_required_rubocop_rails!
 
-        # Mirror a rubocop-rails internal workaround to avoid "Warning: AllCops does not support..." output
+        # Workaround to avoid "Warning: AllCops does not support..." output
         without_warnings do
-          RuboCop::ConfigValidator.const_set(:COMMON_PARAMS, RuboCop::ConfigValidator::COMMON_PARAMS.dup << "MigratedSchemaVersion")
+          RuboCop::ConfigValidator.const_set :COMMON_PARAMS, updated_common_params
         end
 
         LintRoller::Rules.new(
@@ -39,6 +39,12 @@ module Standard
       end
 
       private
+
+      def updated_common_params
+        RuboCop::ConfigValidator::COMMON_PARAMS.dup.tap do |common|
+          %w[MigratedSchemaVersion TargetRailsVersion].each { |param| common << param }
+        end
+      end
 
       def rules_with_config_applied
         @merges_upstream_metadata.merge(

--- a/test/standard/rails/plugin_test.rb
+++ b/test/standard/rails/plugin_test.rb
@@ -12,5 +12,16 @@ module Standard::Rails
 
       assert_equal 5.2, result.value["AllCops"]["TargetRailsVersion"]
     end
+
+    def test_no_parameter_warnings_when_validating_config
+      subject = Plugin.new({})
+      rules = subject.rules(LintRoller::Context.new)
+
+      _out, err = capture_io do
+        RuboCop::Config.create(rules.value, "inline.yml", check: true)
+      end
+
+      assert_equal "", err
+    end
   end
 end


### PR DESCRIPTION
This is an attempt at resolving https://github.com/standardrb/standard-rails/issues/72

As noted in that issue, I only vaguely understand the rubocop rule loading and validating process -- and then both rubocop-rails and standard-rails do some amount of overriding/modifying that process. Anyway, this is a first pass and maybe it's fine or maybe we can find something more elegant.

Concerns here:

- This change is inspired by - https://github.com/rubocop/rubocop-rails/blob/v2.33.3/lib/rubocop/rails/plugin.rb#L27-L32 - which is doing the same sort of warning silencing from within rubocop rails. I don't love the idea of borrowing something which calls itself a dirty hack.
- I'm not actually sure how to produce these warnings from the standard rails test suite itself (I only see it from the full loading process initiated by a separate app), so I'm not sure what test to even add here to avoid regression and/or let us make this more elegant in the future
- I don't really understand how we DONT see a warning for `TargetRailsVersion` (the one worked around in rubocop-rails), since (I think?!) we are overriding the load process such that the rubocop-rails `#rules` method never gets called, and so, one would think, whatever issue that one is working around would need to be re-worked-around?

Benefits:

- If rubocop-rails is doing this internally, maybe it's good enough? (and presumably if/when some cleaner solution emerges we could borrow it?)
- This does indeed silence that output from a local app which otherwise sees the issue, when I update to point at local repo of standard rails with this change

Random side adventure during this journey ... in the other part of this diff, where I added `Lint/UselessAccessModifier` to the existing list to disable for similar reasons, there's some small inconsistency with the comment there and the rules and the history of that whole thing, I think?

- The comment says standard does not enable them to begin with, which is true for `Style/InvertibleUnlessCondition`, but not true for `Lint/SafeNavigationChain` which as of https://github.com/standardrb/standard-rails/pull/22/files#diff-da3213a24b350fa386ff3bab0d6b239112408c3fe4f986cbd9d5236f7e0b61e4R31-R40 is enabled
- The commit which added this "without extended" - https://github.com/standardrb/standard-rails/commit/acccb02885f277c0afcdda358af40040de30ac45 - removes `Lint/RedundantSafeNavigation` and `Style/InvertibleUnlessCondition` from the base config, but then adds `Style/InvertibleUnlessCondition` and `Lint/SafeNavigationChain` to this reject line ... should that latter addition have actually been `Lint/RedundantSafeNavigation` (to match what was removed), and/or should they all be there?
- At minimum maybe that comment needs an update.

Thoughts on all topics welcome.