### PR TITLE
Fix warnings about unsupported RuboCop parameters

### DIFF
--- a/lib/standard/rails/load_rubocop_rails_without_the_monkey_patch.rb
+++ b/lib/standard/rails/load_rubocop_rails_without_the_monkey_patch.rb
@@ -7,7 +7,7 @@
 # of RuboCop built-in cops in this file, we need to monitor it for changes
 # in rubocop-rails and keep it up to date.
 #
-# Last updated from rubocop-rails v2.31.0
+# Last updated from rubocop-rails v2.32.0
 
 # frozen_string_literal: true
 

--- a/test/standard/rails/plugin_test.rb
+++ b/test/standard/rails/plugin_test.rb
@@ -12,5 +12,27 @@ module Standard::Rails
 
       assert_equal 5.2, result.value["AllCops"]["TargetRailsVersion"]
     end
+
+    def test_removes_migrated_schema_version_from_all_cops
+      subject = Plugin.new({})
+
+      result = subject.rules(LintRoller::Context.new)
+
+      refute result.value["AllCops"].key?("MigratedSchemaVersion"),
+        "AllCops should not contain MigratedSchemaVersion parameter"
+    end
+
+    def test_cleans_up_lint_useless_access_modifier
+      subject = Plugin.new({})
+
+      result = subject.rules(LintRoller::Context.new)
+
+      assert_equal({"Enabled" => false}, result.value["Lint/UselessAccessModifier"],
+        "Lint/UselessAccessModifier should only have Enabled parameter")
+      refute result.value["Lint/UselessAccessModifier"].key?("ContextCreatingMethods"),
+        "Lint/UselessAccessModifier should not contain ContextCreatingMethods parameter"
+      refute result.value["Lint/UselessAccessModifier"].key?("inherit_mode"),
+        "Lint/UselessAccessModifier should not contain inherit_mode parameter"
+    end
   end
 end


### PR DESCRIPTION
Resolves #72 by cleaning up Rails-specific parameters that Standard doesn't support:

- Remove MigratedSchemaVersion from AllCops config
- Clean up Lint/UselessAccessModifier to only keep Enabled state

This eliminates the warnings users were seeing after upgrading to version 1.3.0+ when rubocop-rails added these parameters.

Let me know if you want any changes to this. I took a pretty perfunctory approach with some help from Claude Code. My motivation for this fix was that the warnings were filling up my context window w/ Claude Code, so it seemed only appropriate that it help in the work, 